### PR TITLE
Added missing format string

### DIFF
--- a/mux_test.go
+++ b/mux_test.go
@@ -89,7 +89,7 @@ func TestHTTPMux(t *testing.T) {
 
 	resp, err = new(http.Client).Do(req)
 	if err != nil {
-		t.Fatalf("failed to make HTTP request", err)
+		t.Fatalf("failed to make HTTP request: %v", err)
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
`go test` complains about missing format string while building on Fedora rawhide.