### PR TITLE
Add an "AlreadyBound" error, returned by "set"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/inconshreveable/go-vhost
 
-go 1.20
+go 1.12

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/inconshreveable/go-vhost
+
+go 1.20

--- a/mux.go
+++ b/mux.go
@@ -34,6 +34,11 @@ type Closed struct {
 	error
 }
 
+// AlreadyBound is returned when the a vhost is already bound.
+type AlreadyBound struct {
+	error
+}
+
 type (
 	// this is the function you apply to a net.Conn to get
 	// a new virtual-host multiplexed connection
@@ -182,7 +187,7 @@ func (m *VhostMuxer) set(name string, l *Listener) error {
 	m.Lock()
 	defer m.Unlock()
 	if _, exists := m.registry[name]; exists {
-		return fmt.Errorf("name %s is already bound", name)
+		return AlreadyBound{fmt.Errorf("name %s is already bound", name)}
 	}
 	m.registry[name] = l
 	return nil
@@ -232,7 +237,7 @@ func (m *HTTPMuxer) HandleError(conn net.Conn, err error) {
 		return
 	case NotFound:
 		conn.Write([]byte(notFound))
-	case BadRequest:
+	case BadRequest, AlreadyBound:
 		conn.Write([]byte(badRequest))
 	default:
 		if conn != nil {

--- a/mux.go
+++ b/mux.go
@@ -237,8 +237,10 @@ func (m *HTTPMuxer) HandleError(conn net.Conn, err error) {
 		return
 	case NotFound:
 		conn.Write([]byte(notFound))
-	case BadRequest, AlreadyBound:
+	case BadRequest:
 		conn.Write([]byte(badRequest))
+	// AlreadyBound is not handled here by design, as its origin is different,
+	// and it will never make it here.
 	default:
 		if conn != nil {
 			conn.Write([]byte(serverError))


### PR DESCRIPTION
It would be convenient, if there was an AlreadyBound error, so that caller could process it.

This PR implements it.

I tried to follow the style of the original tests, except when I had to create the test for "set", which is the standard table-driven template generated by VSCode.

I have also added `go.mod` file, as when I was making changes it was complaining about not having one.  I did reduce it from 1.20 to 1.12 to ensure that older dependencies won't complain about this library requiring Go 1.20 during build.